### PR TITLE
[RTM] Manually merge the DB definitions from SQL file

### DIFF
--- a/src/Database/Installer.php
+++ b/src/Database/Installer.php
@@ -225,17 +225,7 @@ class Installer
         $files = $this->finder->findIn('config')->depth(0)->files()->name('database.sql');
 
         foreach ($files as $file) {
-            foreach (SqlFileParser::parse($file) as $table => $categories) {
-                foreach ($categories as $category => $fields) {
-                    if (is_array($fields)) {
-                        foreach ($fields as $name => $sql) {
-                            $return[$table][$category][$name] = $sql;
-                        }
-                    } else {
-                        $return[$table][$category] = $fields;
-                    }
-                }
-            }
+            $return = array_replace_recursive($return, SqlFileParser::parse($file));
         }
 
         ksort($return);

--- a/src/Database/Installer.php
+++ b/src/Database/Installer.php
@@ -225,7 +225,17 @@ class Installer
         $files = $this->finder->findIn('config')->depth(0)->files()->name('database.sql');
 
         foreach ($files as $file) {
-            $return = array_merge_recursive($return, SqlFileParser::parse($file));
+            foreach (SqlFileParser::parse($file) as $table => $categories) {
+                foreach ($categories as $category => $fields) {
+                    if (is_array($fields)) {
+                        foreach ($fields as $name => $sql) {
+                            $return[$table][$category][$name] = $sql;
+                        }
+                    } else {
+                        $return[$table][$category] = $fields;
+                    }
+                }
+            }
         }
 
         ksort($return);


### PR DESCRIPTION
The manual for `array_merge_recursive` says:

> If the input arrays have the same string keys, then the values for these keys are merged together into an array

This is wrong in our case, because we don't want to create array out of non-array keys. In my particular case it created an array from each `TABLE_OPTIONS => ENGINE=MyISAM DEFAULT CHARSET=utf8;` which resulted in an incorrect SQL definition.
