### PR TITLE
change locked_explanation (see #30)

### DIFF
--- a/src/Resources/translations/messages.cs.xlf
+++ b/src/Resources/translations/messages.cs.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>Z bezpečnostních důvodů byl instalační nástroj zablokován, protože bylo zadáno více než třikrát špatné heslo. Pro odblokování spustěte na příkazovém řádku tento příkaz &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt;.</target>
+        <target>Z bezpečnostních důvodů byl instalační nástroj zablokován, protože bylo zadáno více než třikrát špatné heslo. Pro odblokování spustěte na příkazovém řádku tento příkaz &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt;.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.de.xlf
+++ b/src/Resources/translations/messages.de.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>Aus Sicherheitsgründen wurde das Installtool gesperrt, nachdem dreimal hintereinander ein falsches Passwort eingegeben wurde. Um es zu entsperren, führen Sie den Befehl &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; auf der Konsole aus.</target>
+        <target>Aus Sicherheitsgründen wurde das Installtool gesperrt, nachdem dreimal hintereinander ein falsches Passwort eingegeben wurde. Um es zu entsperren, führen Sie den Befehl &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; auf der Konsole aus.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.en.xlf
+++ b/src/Resources/translations/messages.en.xlf
@@ -16,7 +16,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>For security reasons, the install tool has been locked after a wrong password had been entered more than three times in a row. To unlock it, run &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; on the command line.</target>
+        <target>For security reasons, the install tool has been locked after a wrong password had been entered more than three times in a row. To unlock it, run &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; on the command line.</target>
       </trans-unit>
       <trans-unit id="5">
         <source>file_permissions_headline</source>

--- a/src/Resources/translations/messages.es.xlf
+++ b/src/Resources/translations/messages.es.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>Por razones de seguridad, la herramienta de instalación ha sido bloqueada después de que se introdujo una contraseña equivocada más de tres veces seguidas. Para desbloquearlo ejecute &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; en la línea de comando.</target>
+        <target>Por razones de seguridad, la herramienta de instalación ha sido bloqueada después de que se introdujo una contraseña equivocada más de tres veces seguidas. Para desbloquearlo ejecute &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; en la línea de comando.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.fr.xlf
+++ b/src/Resources/translations/messages.fr.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>Pour des raisons de sécurité, l'outil d'installation a été verrouillé. Ceci arrive si vous entrez un mauvais mot de passe plus de trois fois d'affilée. Pour le déverrouiller, veuillez exécuter &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; dans votre interface en ligne de commande.</target>
+        <target>Pour des raisons de sécurité, l'outil d'installation a été verrouillé. Ceci arrive si vous entrez un mauvais mot de passe plus de trois fois d'affilée. Pour le déverrouiller, veuillez exécuter &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; dans votre interface en ligne de commande.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.it.xlf
+++ b/src/Resources/translations/messages.it.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>Per ragioni di sicurezza lo strumento di installazione è stato bloccato dopo aver sbagliato la password tre volte. Per sbloccare lo strumento di installazione esegui &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; da linea di comando.</target>
+        <target>Per ragioni di sicurezza lo strumento di installazione è stato bloccato dopo aver sbagliato la password tre volte. Per sbloccare lo strumento di installazione esegui &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; da linea di comando.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.ja.xlf
+++ b/src/Resources/translations/messages.ja.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>セキュリティ上の理由により、連続して3回以上誤ったパスワードを入力した後のインストールツールはロックされています。ロックを解除するにはコマンド行で&lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt;を実行してください。</target>
+        <target>セキュリティ上の理由により、連続して3回以上誤ったパスワードを入力した後のインストールツールはロックされています。ロックを解除するにはコマンド行で&lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt;を実行してください。</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.nl.xlf
+++ b/src/Resources/translations/messages.nl.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>Het installatie programma is om veiligheidsredenen geblokkeerd omdat een wachtwoord meer dan drie keer achter elkaar verkeerd is ingevoerd. Om te ontgrendelen, start &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; op de opdrachtregel.</target>
+        <target>Het installatie programma is om veiligheidsredenen geblokkeerd omdat een wachtwoord meer dan drie keer achter elkaar verkeerd is ingevoerd. Om te ontgrendelen, start &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; op de opdrachtregel.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.ru.xlf
+++ b/src/Resources/translations/messages.ru.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>В целях безопасности, мастер установки Contao заблокирован после ввода, более чем трех раз подряд, неправильного пароля. Для разблокирования, запустите &lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt; в командной строке.</target>
+        <target>В целях безопасности, мастер установки Contao заблокирован после ввода, более чем трех раз подряд, неправильного пароля. Для разблокирования, запустите &lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt; в командной строке.</target>
         
       </trans-unit>
       <trans-unit id="5">

--- a/src/Resources/translations/messages.zh.xlf
+++ b/src/Resources/translations/messages.zh.xlf
@@ -18,7 +18,7 @@
       </trans-unit>
       <trans-unit id="4">
         <source>locked_explanation</source>
-        <target>由于安全原因，连续输入超过3次错误密码安装工具会被锁定，请在命令行中运行&lt;code&gt;app/console doctrine:cache:clear contao.cache&lt;/code&gt;来解除锁定。</target>
+        <target>由于安全原因，连续输入超过3次错误密码安装工具会被锁定，请在命令行中运行&lt;code&gt;app/console cache:clear -e=prod&lt;/code&gt;来解除锁定。</target>
         
       </trans-unit>
       <trans-unit id="5">


### PR DESCRIPTION
As mentioned in #30, the Install Tool tells you to run 

```
app/console doctrine:cache:clear contao.cache
```

when the Install Tool is locked after 3 failed attempts to log in. However, running that command will **not** unlock the Install Tool again. You have to clear the production cache completely with

```
app/console cache:clear -e=prod
```

I am guessing this needs to be changed in the actual transifex repository, however I do not have access to that.
