### PR TITLE
Added bundle requirements to manager plugin

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -10,6 +10,11 @@
 
 namespace Contao\InstallationBundle\ContaoManager;
 
+use Contao\CoreBundle\ContaoCoreBundle;
+use Contao\InstallationBundle\ContaoInstallationBundle;
+use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
+use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
+use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -19,8 +24,20 @@ use Symfony\Component\HttpKernel\KernelInterface;
  *
  * @author Andreas Schempp <https://github.com/aschempp>
  */
-class Plugin implements RoutingPluginInterface
+class Plugin implements BundlePluginInterface, RoutingPluginInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getBundles(ParserInterface $parser)
+    {
+        return [
+            BundleConfig::create(ContaoInstallationBundle::class)
+                ->setLoadAfter([ContaoCoreBundle::class])
+            ,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -33,8 +33,7 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
     {
         return [
             BundleConfig::create(ContaoInstallationBundle::class)
-                ->setLoadAfter([ContaoCoreBundle::class])
-            ,
+                ->setLoadAfter([ContaoCoreBundle::class]),
         ];
     }
 


### PR DESCRIPTION
As discussed in https://github.com/contao/manager-bundle/issues/13, each bundle should require it's dependencies.