### PR TITLE
fix wrong redirect under localhost/foo/web/install.php

### DIFF
--- a/src/HttpKernel/InstallationKernel.php
+++ b/src/HttpKernel/InstallationKernel.php
@@ -124,7 +124,6 @@ class InstallationKernel extends \AppKernel
 
         $context = new RequestContext();
         $context->fromRequest($this->request);
-        $context->setBaseUrl('');
 
         return str_replace('/install.php/', '/', (new UrlGenerator($routes, $context))->generate('contao_install'));
     }


### PR DESCRIPTION
This fixes #18, #25 (again). This change was introduced somewhere between 64588df7185c6c2f8bb53fa62bbd5748cfde3ed7 and a50642379620f92f7db7a2e002a559103c5cf066 (the adding of this line is not documented in the history of the file apparently?).