### PR TITLE
Skip exception when deleting cache directories

### DIFF
--- a/src/Controller/InstallationController.php
+++ b/src/Controller/InstallationController.php
@@ -22,7 +22,6 @@ use Patchwork\Utf8;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
-use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -230,7 +229,7 @@ class InstallationController implements ContainerAwareInterface
      */
     private function purgeSymfonyCache()
     {
-        $fs = new Filesystem();
+        $filesystem = new Filesystem();
         $cacheDir = $this->getContainerParameter('kernel.cache_dir');
 
         /** @var SplFileInfo[] $finder */
@@ -240,12 +239,23 @@ class InstallationController implements ContainerAwareInterface
             ->in(dirname($cacheDir))
         ;
 
-        foreach ($finder as $dir) {
-            try {
-                $fs->remove($dir);
-            } catch (IOException $e) {
-                // Skip exception if not all cache files could be removed
+        foreach ($finder as $realCacheDir) {
+            // the old cache dir name must not be longer than the real one to avoid exceeding
+            // the maximum length of a directory or file path within it (esp. Windows MAX_PATH)
+            $oldCacheDir = substr($realCacheDir, 0, -1).('~' === substr($realCacheDir, -1) ? '+' : '~');
+
+            if (!is_writable($realCacheDir)) {
+                throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
             }
+
+            if ($filesystem->exists($oldCacheDir)) {
+                $filesystem->remove($oldCacheDir);
+            }
+
+            $this->container->get('cache_clearer')->clear($realCacheDir);
+
+            $filesystem->rename($realCacheDir, $oldCacheDir);
+            $filesystem->remove($oldCacheDir);
         }
 
         // Zend OPcache

--- a/src/Controller/InstallationController.php
+++ b/src/Controller/InstallationController.php
@@ -22,6 +22,7 @@ use Patchwork\Utf8;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -240,7 +241,11 @@ class InstallationController implements ContainerAwareInterface
         ;
 
         foreach ($finder as $dir) {
-            $fs->remove($dir);
+            try {
+                $fs->remove($dir);
+            } catch (IOException $e) {
+                // Skip exception if not all cache files could be removed
+            }
         }
 
         // Zend OPcache


### PR DESCRIPTION
Sometimes I got exceptions in the install tool because not all cache files were removed. I think we should ignore that, as it's not gonna be a major issue and breaks the application.