### PR TITLE
fix 'Attempted to load class "Config" from the global namespace' error

### DIFF
--- a/src/Controller/InstallationController.php
+++ b/src/Controller/InstallationController.php
@@ -585,7 +585,7 @@ class InstallationController implements ContainerAwareInterface
             $context['language'] = $this->container->get('translator')->getLocale();
         }
 
-        if (!isset($context['ua'])) {
+        if (!isset($context['ua']) && $this->container->has('contao.framework') && $this->container->get('contao.framework')->isInitialized()) {
             $context['ua'] = Environment::get('agent')->class;
         }
 


### PR DESCRIPTION
If an error occurs during the command tasks of `InstallationController::initializeApplication`, this error cannot be shown to the user, because the `render` method of the `InstallationController` adds the user agent class from the `Contao\Environment` class - and this will try to access `Config::get`, which will not work, because at this point the Contao framework has not been initialised yet, thus resulting in an error:
```
Attempted to load class "Config" from the global namespace.
```
See https://github.com/contao/standard-edition/issues/64

This PR adds a check whether the Contao framework has been initialised yet, before adding the user agent class to the render context.

I wasn't sure about the code formatting with long if conditions. In other places in the Contao framework, they are often kept in one line, so I left it in one line here as well.