### PR TITLE
Missing column check for Contao 4.5 update

### DIFF
--- a/src/Database/Version450Update.php
+++ b/src/Database/Version450Update.php
@@ -27,6 +27,10 @@ class Version450Update extends AbstractVersionUpdate
 
         $columns = $schemaManager->listTableColumns('tl_module');
 
+        if (!isset($columns['news_order'])) {
+            return false;
+        }
+
         return 32 !== $columns['news_order']->getLength();
     }
 


### PR DESCRIPTION
Fixes `Call to a member function getLength() on null`