### PR TITLE
Fix possible null parameter

### DIFF
--- a/src/InstallTool.php
+++ b/src/InstallTool.php
@@ -121,11 +121,11 @@ class InstallTool
     /**
      * Checks if a database connection can be established.
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @return bool
      */
-    public function canConnectToDatabase(string $name): bool
+    public function canConnectToDatabase(string $name = null): bool
     {
         if (null === $this->connection) {
             return false;

--- a/src/InstallTool.php
+++ b/src/InstallTool.php
@@ -125,7 +125,7 @@ class InstallTool
      *
      * @return bool
      */
-    public function canConnectToDatabase(string $name = null): bool
+    public function canConnectToDatabase(?string $name): bool
     {
         if (null === $this->connection) {
             return false;


### PR DESCRIPTION
Before you have set all DB parameters in the install tool, `$name` is `null` and you get following error: 

`
Type error: Argument 1 passed to Contao\InstallationBundle\InstallTool::canConnectToDatabase() must be of the type string, null given
`