### PR TITLE
Check if string before strpos()

### DIFF
--- a/src/Config/ParameterDumper.php
+++ b/src/Config/ParameterDumper.php
@@ -106,7 +106,7 @@ class ParameterDumper
         $parameters = [];
 
         foreach ($this->parameters['parameters'] as $key => $value) {
-            if (false !== strpos($value, '%')) {
+            if (is_string($value) && false !== strpos($value, '%')) {
                 $parameters[$key] = str_replace('%', '%%', $value);
             } else {
                 $parameters[$key] = $value;


### PR DESCRIPTION
Otherwise you get `Type error: strpos() expects parameter 1 to be string, integer given` when the database `port` parameter comes in.