### PR TITLE
Update InstallTool.php

### DIFF
--- a/src/InstallTool.php
+++ b/src/InstallTool.php
@@ -271,7 +271,7 @@ class InstallTool
                 return true;
             }
 
-            $vok = 'mariadb' === strtolower($vendor) ? '10.2' : '5.7.7';
+            $vok = isset($vendor) && 'mariadb' === strtolower($vendor) ? '10.2' : '5.7.7';
 
             // No additional requirements as of MySQL 5.7.7 and MariaDB 10.2
             if (version_compare($version, $vok, '>=')) {


### PR DESCRIPTION
If $vendor is not set at line 222 because `SELECT @@version as Version` only returns a version number you get an error:

> An exception occurred. {"exception":"[object]
 (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: strtolower() expects parameter 1 to be string, null given at /vendor/contao/installation-bundle/src/InstallTool.php:274)