### PR TITLE
Use a double pipe as logical OR for the version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^5.6 || ^7.0",
         "contao/core-bundle": "self.version",
         "sensio/distribution-bundle": "^5.0",
         "sensiolabs/ansi-to-html": "^1.1",
@@ -29,7 +29,7 @@
         "php-http/message-factory": "^1.0.2",
         "phpunit/phpunit": "^5.7.26",
         "satooshi/php-coveralls": "^1.0",
-        "symfony/phpunit-bridge": "^2.8|^3.0"
+        "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
The single pipe `|` operator is considered deprecated but retained for backwards compatibility. For the logical OR version comparison, it is recommended to use the double pipe `||` operator in the `composer.json` as per the [official Composer documentation](https://getcomposer.org/doc/articles/versions.md#version-range).