### PR TITLE
[RFC] Bypass db connection setup when using env component

### DIFF
--- a/src/Controller/InstallationController.php
+++ b/src/Controller/InstallationController.php
@@ -311,9 +311,7 @@ class InstallationController implements ContainerAwareInterface
             throw new \RuntimeException('The request stack did not contain a request');
         }
 
-        // Check if the application is using the env component
-        // If so, and our database connection failed, do not show the form
-        // but only a warning for the user.
+        // Only warn the user if the connection fails and the env component is used
         if (false !== getenv('DATABASE_URL')) {
             return $this->render('misconfigured_database_url.html.twig');
         }

--- a/src/Controller/InstallationController.php
+++ b/src/Controller/InstallationController.php
@@ -311,6 +311,13 @@ class InstallationController implements ContainerAwareInterface
             throw new \RuntimeException('The request stack did not contain a request');
         }
 
+        // Check if the application is using the env component
+        // If so, and our database connection failed, do not show the form
+        // but only a warning for the user.
+        if (false !== getenv('DATABASE_URL')) {
+            return $this->render('misconfigured_database_url.html.twig');
+        }
+
         $parameters = [
             'parameters' => [
                 'database_host' => $this->getContainerParameter('database_host'),

--- a/src/InstallTool.php
+++ b/src/InstallTool.php
@@ -93,6 +93,16 @@ class InstallTool
 
     public function canConnectToDatabase(?string $name): bool
     {
+        // Check if there is already a working connection to
+        // the database. If so, omit further checks.
+        try {
+            $this->connection->connect();
+            $this->connection->query('SHOW TABLES');
+
+            return true;
+        } catch (\Exception $e) {
+        }
+
         if (null === $name || null === $this->connection) {
             return false;
         }

--- a/src/InstallTool.php
+++ b/src/InstallTool.php
@@ -93,8 +93,7 @@ class InstallTool
 
     public function canConnectToDatabase(?string $name): bool
     {
-        // Check if there is already a working connection to
-        // the database. If so, omit further checks.
+        // Return if there is a working database connection already
         try {
             $this->connection->connect();
             $this->connection->query('SHOW TABLES');

--- a/src/Resources/translations/messages.en.xlf
+++ b/src/Resources/translations/messages.en.xlf
@@ -328,7 +328,7 @@
       </trans-unit>
       <trans-unit id="82">
         <source>misconfigured_database_url_explain</source>
-        <target>Could not connect to the database using the connection url found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</target>
+        <target>Could not connect to the database using the connection URL found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</target>
       </trans-unit>
     </body>
   </file>

--- a/src/Resources/translations/messages.en.xlf
+++ b/src/Resources/translations/messages.en.xlf
@@ -327,10 +327,6 @@
         <target>The configured database engine &lt;code&gt;%s&lt;/code&gt; is not available on your server. Please install it (recommended) or configure a different database engine in the &lt;code&gt;app/config/config.yml&lt;/code&gt; file.</target>
       </trans-unit>
       <trans-unit id="82">
-        <source>misconfigured_database_url</source>
-        <target>Could not connect to database!</target>
-      </trans-unit>
-      <trans-unit id="83">
         <source>misconfigured_database_url_explain</source>
         <target>Could not connect to the database using the connection url found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</target>
       </trans-unit>

--- a/src/Resources/translations/messages.en.xlf
+++ b/src/Resources/translations/messages.en.xlf
@@ -326,6 +326,14 @@
         <source>unsupported_engine_explain</source>
         <target>The configured database engine &lt;code&gt;%s&lt;/code&gt; is not available on your server. Please install it (recommended) or configure a different database engine in the &lt;code&gt;app/config/config.yml&lt;/code&gt; file.</target>
       </trans-unit>
+      <trans-unit id="82">
+        <source>misconfigured_database_url</source>
+        <target>Could not connect to database!</target>
+      </trans-unit>
+      <trans-unit id="83">
+        <source>misconfigured_database_url_explain</source>
+        <target>Could not connect to the database using the connection url found in the &lt;code&gt;DATABASE_URL&lt;/code&gt; environment variable.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Resources/views/misconfigured_database_url.html.twig
+++ b/src/Resources/views/misconfigured_database_url.html.twig
@@ -1,0 +1,9 @@
+{% extends "@ContaoInstallation/layout.html.twig" %}
+
+{% block main %}
+    <fieldset class="tl_tbox nolegend">
+        <h3>{{ 'an_error_occurred'|trans }}</h3>
+        <p class="tl_error">{{ 'misconfigured_database_url'|trans }}</p>
+        <p>{{ 'misconfigured_database_url_explain'|trans|raw }}</p>
+    </fieldset>
+{% endblock %}

--- a/src/Resources/views/misconfigured_database_url.html.twig
+++ b/src/Resources/views/misconfigured_database_url.html.twig
@@ -3,7 +3,7 @@
 {% block main %}
     <fieldset class="tl_tbox nolegend">
         <h3>{{ 'an_error_occurred'|trans }}</h3>
-        <p class="tl_error">{{ 'misconfigured_database_url'|trans }}</p>
+        <p class="tl_error">{{ 'database_could_not_connect'|trans }}</p>
         <p>{{ 'misconfigured_database_url_explain'|trans|raw }}</p>
     </fieldset>
 {% endblock %}


### PR DESCRIPTION
Bypass the database connection setup per form if the application is already configured using the env component.

## What it is all about

When using the `symfony/website-skeleton`, you're using the [Dotenv component](http://symfony.com/doc/current/components/dotenv.html) to configure your application. If this is the case, we can basically skip the database setup via the form in the installation bundle, as the dumped `parameters.yml` file will not be included anyway.

## What it does

* [Check for the environment variable DATABASE_URL](https://github.com/sheeep/installation-bundle/blob/fix/allow-env-component-configurations/src/Controller/InstallationController.php#L317), if given, assume the application is configured using the env component.
* [Show a special error message](https://github.com/sheeep/installation-bundle/blob/fix/allow-env-component-configurations/src/Controller/InstallationController.php#L318) if using the env component but the connection to the database failed.
* [Check the given connection](https://github.com/sheeep/installation-bundle/blob/fix/allow-env-component-configurations/src/InstallTool.php#L99-L102). If it doesn't work fall back to the [default behaviour](https://github.com/sheeep/installation-bundle/blob/fix/allow-env-component-configurations/src/InstallTool.php#L106-L128).

## Open points

* [x] Translations. So far, this PR only provides the english translation of the two new string `misconfigured_database_url` and `misconfigured_database_url_explain`.
* [x] Tests

I probably missed quite a few things, so this is RFC.